### PR TITLE
Update README for Vagrant

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -5,28 +5,24 @@ multiple providers (e.g. VMWare ESX, Amazon EC2, KVM, etc.).
 
 ## Usage
 
-You will need to be on an Ubuntu machine (perhaps a VM) to successfully build an
-Ubuntu VM. You can get a VM with the [boxgrinder tools][bg] already installed
-[from S3](https://gds-boxes.s3.amazonaws.com/ubuntu-precise-boxgrinder-20130326.ova).
+Included is a Vagrant configuration for bringing up a "meta-appliance" that
+more-or-less mirrors the definition of `ubuntu-precise-boxgrinder.appl`.
+This will allow you to build subsequent appliances/templates.
 
-Boot the machine and login (either via SSH or at the console) as `root` with
-password `esicerp`.
+Bring it up and login as normal:
+
+    vagrant up
+    vagrant ssh
+
+Boxgrinder needs to be run as root and from a local filesystem with `exec`
+and `dev` mount options. So escalate privileges and change into a new clone
+of the `boxgrinder-appliances` repo:
+
+    sudo -i
+    cd boxgrinder-appliances
 
 You should now be able to build a VM by calling the appropriate `make` task:
 
-    cd boxgrinder-appliances
     make ubuntu-precise
 
 The resulting built VMs will be in the `build/` directory.
-
-## Bootstrapping
-
-If you cannot use the meta-appliance linked above, you should be able to use any
-Ubuntu Precise box. Consult the package list in `ubuntu-precise-boxgrinder.appl`
-and ensure that all the relevant packages are installed on your machine. Then
-review and, as root, run the postinstall script for the boxgrinder
-meta-appliance:
-
-[bg]: http://boxgrinder.org/
-
-    sh script/postinstall-boxgrinder.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,12 +10,7 @@ Vagrant::Config.run do |config|
   config.vm.provision :shell, :path => "script/postinstall-boxgrinder.sh"
 end
 
-Vagrant::VERSION < "1.1.0" and Vagrant.configure("1") do |config|
-  config.vm.share_folder "boxgrinder-appliances", "/home/vagrant/boxgrinder-appliances", ".", :nfs => true
-end
-
 Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
-
   # Configure for the virtualbox provider
   config.vm.provider :virtualbox do |vb, override|
     override.vm.box = BOX_NAME
@@ -28,7 +23,4 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.box_url = VF_BOX_URI
     f.vmx["displayName"] = "boxgrinder"
   end
-
-  config.vm.synced_folder ".", "/home/vagrant/boxgrinder-appliances"
-
 end


### PR DESCRIPTION
This repo now has a Vagrantfile which means that you don't need to download
and import the meta-appliance separately. Update the README to reflect this
simpler method, with a couple of caveats.
## 

Remove shared folders from Vagrantfile - Boxgrinder complains as follows if you try to run it from the shared folder:

VMBuilder.exception.VMBuilderException: Process (['/usr/sbin/debootstrap', '--arch=amd64', 'precise', 'build/appliances/x86_64/ubuntu/precise/ubuntu-precise/1.0/ubuntu-plugin/tmp/tmpqgZ2wY', 'http://arc
hive.ubuntu.com/ubuntu']) returned 1. stdout: E: Cannot install into target '/home/vagrant/boxgrinder-appliances/build/appliances/x86_64/ubuntu/precise/ubuntu-precise/1.0/ubuntu-plugin/tmp/tmpqgZ2wY' mo
unted with noexec or nodev
, stderr: mknod: `/home/vagrant/boxgrinder-appliances/build/appliances/x86_64/ubuntu/precise/ubuntu-precise/1.0/ubuntu-plugin/tmp/tmpqgZ2wY/test-dev-null': Operation not permitted

So remove them, in order to save confusion with `/root/boxgrinder-appliances`.
## 

/cc @samjsharpe @annashipman @nickstenning
