### PR TITLE
Default network and testing

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -40,8 +40,8 @@ To test it against Skyscape to check the XML is valid, etc, do the following:
 
     VM_NAME="ubuntu-precise-$(date +%Y%m%d%H%M)-$(git rev-parse --short HEAD)";
 
-    ovftool -n=$VM_NAME --vCloudTemplate
-    build/appliances/x86_64/ubuntu/precise/ubuntu-precise/1.0/vmware-plugin/ubuntu-precise.ova
+    ovftool -n=$VM_NAME --vCloudTemplate \
+    build/appliances/x86_64/ubuntu/precise/ubuntu-precise/1.0/vmware-plugin/ubuntu-precise.ova \
     "vcloud://${USER_ID}@api.vcd.portal.skyscapecloud.com/?org=${ORG_ID}&vdc=${FRIENDLY_ORG_NAME}&catalog=Default&vappTemplate=${VM_NAME}"
 
 You'll need to set `USER_ID`, `ORG_ID` and `FRIENDLY_ORG_NAME` (the latter can

--- a/README.mkd
+++ b/README.mkd
@@ -33,3 +33,16 @@ If you make changes you will need to delete the build directory - or just
 
 Sometimes it hangs for a very long time. You might find that destroying the VM
 and starting again is quicker.
+
+## Testing
+
+To test it against Skyscape to check the XML is valid, etc, do the following:
+
+    VM_NAME="ubuntu-precise-$(date +%Y%m%d%H%M)-$(git rev-parse --short HEAD)";
+
+    ovftool -n=$VM_NAME --vCloudTemplate
+    build/appliances/x86_64/ubuntu/precise/ubuntu-precise/1.0/vmware-plugin/ubuntu-precise.ova
+    "vcloud://${USER_ID}@api.vcd.portal.skyscapecloud.com/?org=${ORG_ID}&vdc=${FRIENDLY_ORG_NAME}&catalog=Default&vappTemplate=${VM_NAME}"
+
+You'll need to set `USER_ID`, `ORG_ID` and `FRIENDLY_ORG_NAME` (the latter can
+be found on the Administration tab in vCloud Director; use `%20` for spaces).

--- a/README.mkd
+++ b/README.mkd
@@ -26,3 +26,10 @@ You should now be able to build a VM by calling the appropriate `make` task:
     make ubuntu-precise
 
 The resulting built VMs will be in the `build/` directory.
+
+If you make changes you will need to delete the build directory - or just
+
+    make clean
+
+Sometimes it hangs for a very long time. You might find that destroying the VM
+and starting again is quicker.

--- a/bin/ovf-customizer
+++ b/bin/ovf-customizer
@@ -26,13 +26,20 @@ vst_tag.firstChild.replaceWholeText('vmx-08')
 
 # Change network name to Default.
 net_name = 'Default'
+net_description = 'The Default network'
+conn_description = 'PCNet32 ethernet adapter on "Default"'
 
 net_tag = dom.getElementsByTagName('NetworkSection')[0]
 net_tag = net_tag.getElementsByTagName('Network')[0]
 net_tag.setAttribute('ovf:name', net_name)
+description_tag = net_tag.getElementsByTagName('Description')[0]
+description_tag.firstChild.replaceWholeText(net_description)
 
 conn_tag = dom.getElementsByTagName('rasd:Connection')[0]
 conn_tag.firstChild.replaceWholeText(net_name)
+item_tag = conn_tag.parentNode
+description_tag = item_tag.getElementsByTagName('rasd:Description')[0]
+description_tag.firstChild.replaceWholeText(conn_description)
 
 # Add the vCloud customization section at the end of the VirtualSystem tag
 vs_tag = dom.getElementsByTagName('VirtualSystem')[0]


### PR DESCRIPTION
This PR changes the ovf-customiser so that all references to nat are replaced with Default (there were some in the descriptions).

It also adds instructions for testing changes against Skyscape.
